### PR TITLE
Sniff to a file, split by hour/day

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -72,6 +72,15 @@ $ path/to/whsniff -c channel_number > /tmp/pipes/whsniff
 ```sh
 $ path/to/whsniff -c channel_number > filename.pcap
 ```
+* You can also let whsniff save the output to a file, whsniff will generate a file name that indicates sniffing start date/time
+```sh
+$ path/to/whsniff -c channel_number -f
+```
+* You can also let whsniff save the output to a file, and automatically restart sniffing every hour (-h) or day (-d) so that a single file is not too huge
+```sh
+$ path/to/whsniff -c channel_number -f -h
+$ path/to/whsniff -c channel_number -f -d
+```
 * You can also keep the original FCS sent by the CC2531 through the -k option. The original FCS contains the RSSI and LQI. It can be interpreted by wireshark as a "TI CC24xx FCS format":
 ```sh
 $ path/to/whsniff -k -c channel_number > /tmp/pipes/whsniff

--- a/src/whsniff.c
+++ b/src/whsniff.c
@@ -358,8 +358,13 @@ FILE * restart_pcap_file(FILE * prev_file)
 			fclose(prev_file);
 
 		// Open a new file 
-		// TODO: generate new file name
-		file = fopen("whsniff.pcap", "wb");
+		char filename[100];
+		time_t t = time(NULL);
+		struct tm tm = *localtime(&t);
+		sprintf(filename, "whsniff-%d-%02d-%02d-%02d-%02d-%02d.pcap", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+		fprintf(stderr, "Sniffing to %s\n", filename);
+		file = fopen(filename, "wb");
 	}
 
 	// Write PCAP header


### PR DESCRIPTION
I am debugging an intermittent issue, which happen once in a few days. Sniffing zigbee traffic for several days is possible, but logs appear quite huge and inconvinient to analyze. With this change I am introducing a way to dump zigbee traffic to a file, and create a new file every hour or day.

whsniff now has a few new command line switches:
- `-f` will dump zigbee traffic to a file, rather than stdout
- `-h` and `-d` will create a new file every hour or day

File name is currently can't be specified from command line, and generated by the app. File name includes date/time when file was started. No files rotation is implemented.

Additionally I make a small refactoring, extracting USB initialization/deinitialization to separate functions.

Alternatives considered: I was thinking about restarting whsniff on cron, or creating a wrapper script that would restart whsniff. Disadvantage of this approach is possible missing messages that could happen while whsniff is restarting. That is why I decided to implement this logic in whsniff - it is changing files, not disconnecting from USB sniffer.