### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 
 # Installation directories by convention
 # http://www.gnu.org/prep/standards/html_node/Directory-Variables.html
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 EXEC_PREFIX = $(PREFIX)
 BINDIR = $(EXEC_PREFIX)/bin
 SYSCONFDIR = $(PREFIX)/etc

--- a/src/whsniff.c
+++ b/src/whsniff.c
@@ -271,7 +271,8 @@ libusb_device_handle * init_usb_sniffer(uint8_t channel)
 			if (libusb_kernel_driver_active(handle, 0))
 			{
 				res = libusb_detach_kernel_driver(handle, 0);
-				if (res < 0)
+				// If it's not supported (like on OpenBSD), just keep going!
+				if (res < 0 && res != LIBUSB_ERROR_NOT_SUPPORTED)
 				{
 					fprintf(stderr, "ERROR: Could not detach kernel driver from CC2531 USB Dongle.\n");
 					libusb_close(handle);


### PR DESCRIPTION
Tiny fix to allow using whsniff on OpenBSD. Same fix was used in Kismet ticc2531 capture source as well.
While there on the Makefile, allow overriding PREFIX, to please packagers.